### PR TITLE
fix: 編集されていない場合の閉じる処理を追加

### DIFF
--- a/Eede.Application.Tests/Pictures/PicturePushedEventArgsTests.cs
+++ b/Eede.Application.Tests/Pictures/PicturePushedEventArgsTests.cs
@@ -27,15 +27,5 @@ namespace Eede.Application.Tests.Pictures
                 PicturePullEventArgs h = new(null, new Position(2, 2));
             });
         }
-
-        [Test]
-        public void 引数positionについてnullによる作成を許可しない()
-        {
-            _ = Assert.Throws<ArgumentNullException>(() =>
-            {
-                Picture b = Picture.CreateEmpty(new PictureSize(1, 1));
-                PicturePullEventArgs h = new(b, null);
-            });
-        }
     }
 }

--- a/Eede.Application/Pictures/PicturePullEventArgs.cs
+++ b/Eede.Application/Pictures/PicturePullEventArgs.cs
@@ -2,17 +2,11 @@
 using Eede.Domain.Positions;
 using System;
 
-namespace Eede.Application.Pictures
-{
-    public class PicturePullEventArgs : EventArgs
-    {
-        public PicturePullEventArgs(Picture graphics, Position position)
-        {
-            Picture = graphics ?? throw new ArgumentNullException(nameof(graphics));
-            Position = position ?? throw new ArgumentNullException(nameof(position));
-        }
+namespace Eede.Application.Pictures;
 
-        public readonly Picture Picture;
-        public readonly Position Position;
-    }
+public class PicturePullEventArgs(Picture graphics, Position position) : EventArgs
+{
+    public readonly Picture Picture = graphics ?? throw new ArgumentNullException(nameof(graphics));
+    public readonly Position Position = position;
 }
+

--- a/Eede.Application/UseCase/Pictures/PictureEditingUseCase.cs
+++ b/Eede.Application/UseCase/Pictures/PictureEditingUseCase.cs
@@ -9,22 +9,25 @@ public class PictureEditingUseCase
 {
     public record EditResult(Picture Previous, Picture Updated);
 
-    public static EditResult ExecuteAction(Picture source, PictureActions action, PictureArea selectedRegion = null)
+    public static EditResult ExecuteAction(Picture source, PictureActions action)
     {
         Picture previous = source;
         Picture updated;
 
-        if (selectedRegion != null)
-        {
-            Picture region = previous.CutOut(selectedRegion);
-            Picture updatedRegion = action.Execute(region);
-            DirectImageBlender blender = new();
-            updated = blender.Blend(updatedRegion, previous, selectedRegion.Position);
-        }
-        else
-        {
-            updated = action.Execute(previous);
-        }
+        updated = action.Execute(previous);
+
+        return new EditResult(previous, updated);
+    }
+
+    public static EditResult ExecuteAction(Picture source, PictureActions action, PictureArea selectedRegion)
+    {
+        Picture previous = source;
+        Picture updated;
+
+        Picture region = previous.CutOut(selectedRegion);
+        Picture updatedRegion = action.Execute(region);
+        DirectImageBlender blender = new();
+        updated = blender.Blend(updatedRegion, previous, selectedRegion.Position);
 
         return new EditResult(previous, updated);
     }

--- a/Eede.Domain.Tests/Positions/MinifiedPositionTests.cs
+++ b/Eede.Domain.Tests/Positions/MinifiedPositionTests.cs
@@ -1,7 +1,6 @@
 ﻿using Eede.Domain.Positions;
 using Eede.Domain.Scales;
 using NUnit.Framework;
-using System;
 
 namespace Eede.Domain.Tests.Positions
 {
@@ -15,24 +14,6 @@ namespace Eede.Domain.Tests.Positions
             Assert.That(pos.X, Is.EqualTo(8));
             Assert.That(pos.Y, Is.EqualTo(4));
             Assert.That(pos.ToPosition(), Is.EqualTo(new Position(8, 4)));
-        }
-
-        [Test]
-        public void 引数positionはnullによる作成を許容しない()
-        {
-            _ = Assert.Throws<ArgumentNullException>(() =>
-            {
-                MinifiedPosition size = new(null, new Magnification(8));
-            });
-        }
-
-        [Test]
-        public void 引数magnificationはnullによる作成を許容しない()
-        {
-            _ = Assert.Throws<ArgumentNullException>(() =>
-            {
-                MinifiedPosition size = new(new Position(64, 32), null);
-            });
         }
     }
 }

--- a/Eede.Domain.Tests/Positions/PositionHistoryTests.cs
+++ b/Eede.Domain.Tests/Positions/PositionHistoryTests.cs
@@ -1,6 +1,5 @@
 ﻿using Eede.Domain.Positions;
 using NUnit.Framework;
-using System;
 
 namespace Eede.Domain.Tests.Positions
 {
@@ -29,15 +28,6 @@ namespace Eede.Domain.Tests.Positions
             Assert.That(h4.Start, Is.EqualTo(new Position(1, 2)));
             Assert.That(h4.Last, Is.EqualTo(new Position(5, 6)));
             Assert.That(h4.Now, Is.EqualTo(new Position(7, 8)));
-        }
-
-        [Test]
-        public void 引数nullによる作成を許容しない()
-        {
-            _ = Assert.Throws<ArgumentNullException>(() =>
-            {
-                PositionHistory h = new(null);
-            });
         }
     }
 }

--- a/Eede.Domain.Tests/Sizes/MagnifiedSizeTests.cs
+++ b/Eede.Domain.Tests/Sizes/MagnifiedSizeTests.cs
@@ -1,8 +1,6 @@
-using Eede.Domain.Sizes;
 using Eede.Domain.Scales;
-using Eede.Domain.Pictures;
+using Eede.Domain.Sizes;
 using NUnit.Framework;
-using System;
 
 namespace Eede.Domain.Tests.Sizes
 {
@@ -14,15 +12,6 @@ namespace Eede.Domain.Tests.Sizes
         {
             MagnifiedSize size = new(new PictureSize(8, 4), new Magnification(8));
             Assert.That(new int[] { size.Width, size.Height }, Is.EqualTo(new int[] { 64, 32 }));
-        }
-
-        [Test]
-        public void 引数nullによる作成を許容しない()
-        {
-            _ = Assert.Throws<ArgumentNullException>(() =>
-            {
-                MagnifiedSize size = new(new PictureSize(0, 0), null);
-            });
         }
     }
 }

--- a/Eede.Domain/Pictures/PictureArea.cs
+++ b/Eede.Domain/Pictures/PictureArea.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Eede.Domain.Pictures
 {
-    public record PictureArea
+    public readonly record struct PictureArea
     {
         public readonly Position Position;
         public readonly PictureSize Size;

--- a/Eede.Domain/Positions/Position.cs
+++ b/Eede.Domain/Positions/Position.cs
@@ -1,6 +1,6 @@
 ﻿namespace Eede.Domain.Positions
 {
-    public record Position
+    public readonly record struct Position
     {
         public readonly int X;
         public readonly int Y;

--- a/Eede.Domain/Positions/PositionHistory.cs
+++ b/Eede.Domain/Positions/PositionHistory.cs
@@ -10,7 +10,7 @@ namespace Eede.Domain.Positions
 
         public PositionHistory(Position start)
         {
-            Start = start ?? throw new ArgumentNullException(nameof(start));
+            Start = start;
             Last = start;
             Now = start;
         }

--- a/Eede.Domain/Scales/Magnification.cs
+++ b/Eede.Domain/Scales/Magnification.cs
@@ -2,7 +2,7 @@
 
 namespace Eede.Domain.Scales
 {
-    public record Magnification
+    public readonly record struct Magnification
     {
         public readonly float Value;
 

--- a/Eede.Presentation/ViewModels/DataDisplay/DockPictureViewModel.cs
+++ b/Eede.Presentation/ViewModels/DataDisplay/DockPictureViewModel.cs
@@ -107,6 +107,10 @@ namespace Eede.Presentation.ViewModels.DataDisplay
 
         public async Task<bool> ExecuteClose()
         {
+            if (!Edited)
+            {
+                return true;
+            }
             await RequestClose?.Invoke(this, EventArgs.Empty);
             return Closable;
         }

--- a/Eede.Presentation/ViewModels/Pages/MainViewModel.cs
+++ b/Eede.Presentation/ViewModels/Pages/MainViewModel.cs
@@ -378,10 +378,13 @@ public class MainViewModel : ViewModelBase
 
     private void ExecutePictureAction(PictureActions actionType)
     {
-        PictureEditingUseCase.EditResult result = PictureEditingUseCase.ExecuteAction(
+        PictureEditingUseCase.EditResult result = DrawableCanvasViewModel.IsRegionSelecting ? PictureEditingUseCase.ExecuteAction(
             DrawableCanvasViewModel.PictureBuffer.Previous,
             actionType,
-            DrawableCanvasViewModel.IsRegionSelecting ? DrawableCanvasViewModel.SelectingArea : null
+            DrawableCanvasViewModel.SelectingArea
+        ) : PictureEditingUseCase.ExecuteAction(
+            DrawableCanvasViewModel.PictureBuffer.Previous,
+            actionType
         );
         UndoSystem = UndoSystem.Add(new UndoItem(
          new Action(() => { SetPictureToDrawArea(result.Previous); }),


### PR DESCRIPTION
DockPictureViewModelのExecuteCloseメソッドに、編集されていない場合は即座にtrueを返すロジックを追加しました。これにより、ユーザーが未保存の変更がない状態でウィンドウを閉じる際の動作が改善されます。