### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop-release.yml
+++ b/.github/workflows/dotnet-desktop-release.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: write
 name: .NET Core Desktop Release
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/arkfinn/Eede/security/code-scanning/1](https://github.com/arkfinn/Eede/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the top level (applies to all jobs), unless different jobs require different permissions. For this workflow, the main job checks out code and uploads release assets. The minimal required permissions are `contents: read` for most steps, but the release asset upload (`softprops/action-gh-release`) requires `contents: write`. Therefore, set `contents: write` at the workflow level. If you want to be more restrictive, you could set `contents: read` at the workflow level and `contents: write` only for the job that uploads assets, but since there is only one job, setting it at the root is sufficient.

Add the following block after the `name:` line and before the `on:` block:

```yaml
permissions:
  contents: write
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
