### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop-ci.yml
+++ b/.github/workflows/dotnet-desktop-ci.yml
@@ -1,5 +1,8 @@
 name: .NET Core Desktop CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/arkfinn/Eede/security/code-scanning/2](https://github.com/arkfinn/Eede/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow. Since the job only checks out code and runs tests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow (before `jobs:`), which will apply to all jobs unless overridden. This change should be made at the top of the file, after the `name:` and before the `on:` block. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
