### PR TITLE
🧹 Code Health: Remove commented-out code in DrawableArea.cs

### DIFF
--- a/Eede.Application/Drawings/DrawableArea.cs
+++ b/Eede.Application/Drawings/DrawableArea.cs
@@ -43,8 +43,6 @@ namespace Eede.Application.Drawings
             Picture picture = source;
             // 表示上のサイズ・ポジション DisplaySize DisplayPosition
             MagnifiedSize displaySize = Magnify(source.Size);
-            //PaintBackgroundLayer backgroundLayer = new(Background);
-            //var picture = backgroundLayer.Painted(null);
 
             if (!buffer.IsDrawing() && PositionHistory != null)
             {
@@ -57,8 +55,6 @@ namespace Eede.Application.Drawings
                 picture = bufferLayer.Painted(picture);
             }
 
-            //PaintGridLayer gridLayer = new(displaySize, Magnify(GridSize));
-            //picture = gridLayer.Paint(picture);
             return picture;
         }
 


### PR DESCRIPTION
🎯 **What:** Removed commented-out code snippets related to `PaintBackgroundLayer` and `PaintGridLayer` in `Eede.Application/Drawings/DrawableArea.cs`.
💡 **Why:** Dead, commented-out code clutters the file and decreases readability without providing value. Removing it improves maintainability.
✅ **Verification:** Verified that the removal doesn't introduce compilation errors and confirmed tests compile properly. The removed code was not actively executing.
✨ **Result:** A cleaner `DrawableArea.cs` file with less noise.

---
*PR created automatically by Jules for task [1001950368792496650](https://jules.google.com/task/1001950368792496650) started by @arkfinn*