### PR TITLE
🧹 Remove commented-out switch case in PictureActions

### DIFF
--- a/Eede.Domain/ImageEditing/GeometricTransformations/PictureActions.cs
+++ b/Eede.Domain/ImageEditing/GeometricTransformations/PictureActions.cs
@@ -29,8 +29,6 @@ public static class PictureActionsExtension
             PictureActions.ShiftRight => new ShiftRightAction(previous).Execute(),
             PictureActions.FlipHorizontal => new FlipHorizontalAction(previous).Execute(),
             PictureActions.FlipVertical => new FlipVerticalAction(previous).Execute(),
-            //case PictureActions.RotateLeft:
-            //    return;
             PictureActions.RotateRight => new RotateRightAction(previous).Execute(),
             PictureActions.MirrorCopyRight => new MirrorCopyRightAction(previous).Execute(),
             PictureActions.MirrorCopyBottom => new MirrorCopyBottomAction(previous).Execute(),


### PR DESCRIPTION
🎯 **What:** Removed the commented-out code (`//case PictureActions.RotateLeft: //return;`) from the switch expression in `PictureActions.cs`.
💡 **Why:** Cleans up the code and improves maintainability by removing dead code.
✅ **Verification:** Compiled the project successfully with `dotnet build /p:EnableWindowsTargeting=true` and verified tests run with nunit console runner without regressions.
✨ **Result:** A cleaner switch expression in the `Execute` extension method.

---
*PR created automatically by Jules for task [4486542123945218345](https://jules.google.com/task/4486542123945218345) started by @arkfinn*