### PR TITLE
🧪 Add tests for AddRecentFile in AppSettings

### DIFF
--- a/Eede.Infrastructure.Tests/Settings/AppSettingsTests.cs
+++ b/Eede.Infrastructure.Tests/Settings/AppSettingsTests.cs
@@ -30,4 +30,62 @@ public class AppSettingsTests
         Assert.That(deserialized.RecentFiles[0].Path, Is.EqualTo("test.png"));
         Assert.That(deserialized.RecentFiles[0].LastAccessed, Is.EqualTo(new System.DateTime(2026, 2, 17)));
     }
+
+    [Test]
+    public void AddRecentFile_AddsNewFileToBeginning_WhenFileDoesNotExist()
+    {
+        var settings = new AppSettings();
+        settings.RecentFiles = new System.Collections.Generic.List<RecentFile>
+        {
+            new RecentFile { Path = "test1.png", LastAccessed = new System.DateTime(2026, 2, 17) }
+        };
+
+        var newTime = new System.DateTime(2026, 2, 18);
+        settings.AddRecentFile("test2.png", newTime);
+
+        Assert.That(settings.RecentFiles.Count, Is.EqualTo(2));
+        Assert.That(settings.RecentFiles[0].Path, Is.EqualTo("test2.png"));
+        Assert.That(settings.RecentFiles[0].LastAccessed, Is.EqualTo(newTime));
+        Assert.That(settings.RecentFiles[1].Path, Is.EqualTo("test1.png"));
+    }
+
+    [Test]
+    public void AddRecentFile_MovesExistingFileToBeginning_WhenFileExists()
+    {
+        var settings = new AppSettings();
+        settings.RecentFiles = new System.Collections.Generic.List<RecentFile>
+        {
+            new RecentFile { Path = "test1.png", LastAccessed = new System.DateTime(2026, 2, 17) },
+            new RecentFile { Path = "test2.png", LastAccessed = new System.DateTime(2026, 2, 16) }
+        };
+
+        var newTime = new System.DateTime(2026, 2, 18);
+        settings.AddRecentFile("test2.png", newTime);
+
+        Assert.That(settings.RecentFiles.Count, Is.EqualTo(2));
+        Assert.That(settings.RecentFiles[0].Path, Is.EqualTo("test2.png"));
+        Assert.That(settings.RecentFiles[0].LastAccessed, Is.EqualTo(newTime));
+        Assert.That(settings.RecentFiles[1].Path, Is.EqualTo("test1.png"));
+    }
+
+    [Test]
+    public void AddRecentFile_LimitsListTo10Items_WhenMoreThan10Added()
+    {
+        var settings = new AppSettings();
+        settings.RecentFiles = new System.Collections.Generic.List<RecentFile>();
+
+        for (int i = 0; i < 10; i++)
+        {
+            settings.RecentFiles.Add(new RecentFile { Path = $"test{i}.png", LastAccessed = new System.DateTime(2026, 2, 17) });
+        }
+
+        Assert.That(settings.RecentFiles.Count, Is.EqualTo(10));
+        var newTime = new System.DateTime(2026, 2, 18);
+        settings.AddRecentFile("test10.png", newTime);
+
+        Assert.That(settings.RecentFiles.Count, Is.EqualTo(10));
+        Assert.That(settings.RecentFiles[0].Path, Is.EqualTo("test10.png"));
+        Assert.That(settings.RecentFiles[0].LastAccessed, Is.EqualTo(newTime));
+        Assert.That(settings.RecentFiles[9].Path, Is.EqualTo("test8.png"));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `AddRecentFile` functionality in `AppSettings.cs` was lacking tests. This function manages the recent files list and limits it to 10 entries.
📊 **Coverage:** Added tests to cover:
- Inserting a new file to the beginning of the list.
- Moving an already-existing file to the beginning.
- Ensuring the list trims older files if it exceeds 10 entries.
✨ **Result:** Improved test coverage for `AppSettings.cs`, ensuring recent files are maintained correctly.

---
*PR created automatically by Jules for task [16473048927375565581](https://jules.google.com/task/16473048927375565581) started by @arkfinn*