### PR TITLE
🧹 Fix empty catch block in AvaloniaBitmapAdapter

### DIFF
--- a/Eede.Presentation/Common/Adapters/AvaloniaBitmapAdapter.cs
+++ b/Eede.Presentation/Common/Adapters/AvaloniaBitmapAdapter.cs
@@ -135,7 +135,10 @@ namespace Eede.Presentation.Common.Adapters
                 {
                     bitmap.CopyPixels(new PixelRect(0, 0, width, height), pinnedArray.AddrOfPinnedObject(), pixels.Length, width * 4);
                 }
-                catch (Exception) { }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine(ex);
+                }
                 finally
                 {
                     pinnedArray.Free();


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Added logging to an empty catch block in `AvaloniaBitmapAdapter`. 

💡 **Why:** How this improves maintainability
Silent failure can mask bugs during development. By adding `System.Diagnostics.Debug.WriteLine(ex);` inside the empty block, developers will be aware of exceptions occurring during pixel copying operations without crashing the application flow.

✅ **Verification:** How you confirmed the change is safe
The change is a trivial one-liner that utilizes `System.Diagnostics.Debug`, introducing no behavior change in Release builds and safely surfacing information in Debug builds. Verified locally without build regressions (ignoring container-specific WindowsForms reference issues).

✨ **Result:** The improvement achieved
A cleaner and more debuggable presentation layer.

---
*PR created automatically by Jules for task [10825180230297922024](https://jules.google.com/task/10825180230297922024) started by @arkfinn*