### PR TITLE
🧪 Add test for UpdateMagnification in DrawableArea.cs

### DIFF
--- a/Eede.Application.Tests/Drawings/DrawableAreaTests.cs
+++ b/Eede.Application.Tests/Drawings/DrawableAreaTests.cs
@@ -86,5 +86,24 @@ namespace Eede.Application.Tests.Drawings
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => drawableArea.DisplaySizeOf(null));
         }
+
+        [Test]
+        public void UpdateMagnification_ReturnsNewInstanceWithUpdatedMagnification()
+        {
+            // Arrange
+            var initialMagnification = new Magnification(1.0f);
+            var newMagnification = new Magnification(3.0f);
+            var gridSize = new PictureSize(16, 16);
+            var drawableArea = new DrawableArea(initialMagnification, gridSize, null);
+
+            // Act
+            var updatedArea = drawableArea.UpdateMagnification(newMagnification);
+
+            // Assert
+            Assert.That(updatedArea, Is.Not.Null);
+            Assert.That(updatedArea, Is.Not.SameAs(drawableArea));
+            Assert.That(updatedArea.Magnification, Is.EqualTo(newMagnification));
+            Assert.That(drawableArea.Magnification, Is.EqualTo(initialMagnification), "Original instance should remain unchanged.");
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: The `UpdateMagnification` method in `DrawableArea` lacked test coverage. It's a pure function meant to return a new instance with updated magnification while maintaining immutability.

📊 **Coverage:** What scenarios are now tested: The new test `UpdateMagnification_ReturnsNewInstanceWithUpdatedMagnification` ensures that invoking the method:
- Returns a non-null instance.
- Returns a different instance than the original (`Is.Not.SameAs`).
- Has the updated `Magnification` property.
- Does not alter the `Magnification` of the original instance.

✨ **Result:** The improvement in test coverage: We now have automated verification that `UpdateMagnification` correctly exhibits pure function behavior without unexpected side effects, enabling confident refactoring.

---
*PR created automatically by Jules for task [3171946283778318935](https://jules.google.com/task/3171946283778318935) started by @arkfinn*