### PR TITLE
🧪 Add tests for DrawingResult

### DIFF
--- a/Eede.Application.Tests/Drawings/DrawingResultTests.cs
+++ b/Eede.Application.Tests/Drawings/DrawingResultTests.cs
@@ -1,0 +1,61 @@
+using Eede.Application.Drawings;
+using Eede.Domain.ImageEditing.DrawingTools;
+using Eede.Domain.SharedKernel;
+using NUnit.Framework;
+
+namespace Eede.Application.Tests.Drawings
+{
+    [TestFixture]
+    public class DrawingResultTests
+    {
+        [Test]
+        public void Constructor_InitializesPropertiesCorrectly()
+        {
+            // Arrange
+            var picture = Eede.Domain.ImageEditing.Picture.CreateEmpty(new PictureSize(10, 10));
+            var buffer = new DrawingBuffer(picture);
+            var drawableArea = new DrawableArea(new Eede.Domain.ImageEditing.Magnification(1.0f), new PictureSize(16, 16), null);
+            var region = new PictureRegion(new PictureArea(new Position(1, 1), new PictureSize(5, 5)));
+
+            // Act
+            var result = new DrawingResult(buffer, drawableArea, region);
+
+            // Assert
+            Assert.That(result.PictureBuffer, Is.SameAs(buffer));
+            Assert.That(result.DrawableArea, Is.SameAs(drawableArea));
+            Assert.That(result.AffectedArea, Is.EqualTo(region));
+        }
+
+        [Test]
+        public void Constructor_WithDefaultAffectedArea_InitializesPropertiesCorrectly()
+        {
+            // Arrange
+            var picture = Eede.Domain.ImageEditing.Picture.CreateEmpty(new PictureSize(10, 10));
+            var buffer = new DrawingBuffer(picture);
+            var drawableArea = new DrawableArea(new Eede.Domain.ImageEditing.Magnification(1.0f), new PictureSize(16, 16), null);
+
+            // Act
+            var result = new DrawingResult(buffer, drawableArea);
+
+            // Assert
+            Assert.That(result.PictureBuffer, Is.SameAs(buffer));
+            Assert.That(result.DrawableArea, Is.SameAs(drawableArea));
+            Assert.That(result.AffectedArea.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void Constructor_WithNullBuffer_InitializesPropertiesCorrectly()
+        {
+            // Arrange
+            var drawableArea = new DrawableArea(new Eede.Domain.ImageEditing.Magnification(1.0f), new PictureSize(16, 16), null);
+
+            // Act
+            var result = new DrawingResult(null, drawableArea);
+
+            // Assert
+            Assert.That(result.PictureBuffer, Is.Null);
+            Assert.That(result.DrawableArea, Is.SameAs(drawableArea));
+            Assert.That(result.AffectedArea.IsEmpty, Is.True);
+        }
+    }
+}

--- a/test_compilation.sh
+++ b/test_compilation.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+dotnet build Eede.Application.Tests/Eede.Application.Tests.csproj /p:EnableWindowsTargeting=true


### PR DESCRIPTION
🎯 **What:** Added unit tests for `Eede.Application.Drawings.DrawingResult`. The issue mentioned a different structure for this class, but checking the codebase, the actual class structure is used extensively across `DrawableArea` and other parts of the application. Therefore, tests were written against the actual implemented class to ensure correctness and prevent regressions.

📊 **Coverage:** Covered normal instantiation, instantiation with default parameter `affectedArea`, and instantiation with a null `picture` buffer.

✨ **Result:** Enhanced test coverage for the `DrawingResult` value object.

---
*PR created automatically by Jules for task [12317154037304465999](https://jules.google.com/task/12317154037304465999) started by @arkfinn*