### PR TITLE
🧪 Add tests for SelectionPreviewInfo SourcePixels initialization

### DIFF
--- a/Eede.Domain.Tests/ImageEditing/SelectionPreviewInfoTests.cs
+++ b/Eede.Domain.Tests/ImageEditing/SelectionPreviewInfoTests.cs
@@ -1,0 +1,62 @@
+using Eede.Domain.ImageEditing;
+using Eede.Domain.SharedKernel;
+using NUnit.Framework;
+
+namespace Eede.Domain.Tests.ImageEditing;
+
+[TestFixture]
+public class SelectionPreviewInfoTests
+{
+    [Test]
+    public void Constructor_WithoutSourcePixels_SetsSourcePixelsToPixels()
+    {
+        var pixels = Picture.CreateEmpty(new PictureSize(10, 10));
+        var position = new Position(5, 5);
+
+        var info = new SelectionPreviewInfo(pixels, position);
+
+        Assert.That(info.SourcePixels, Is.SameAs(pixels));
+    }
+
+    [Test]
+    public void Constructor_WithSourcePixels_SetsSourcePixelsToProvidedValue()
+    {
+        var pixels = Picture.CreateEmpty(new PictureSize(10, 10));
+        var sourcePixels = Picture.CreateEmpty(new PictureSize(20, 20));
+        var position = new Position(5, 5);
+
+        var info = new SelectionPreviewInfo(pixels, position, SelectionPreviewType.CutAndMove, null, sourcePixels);
+
+        Assert.That(info.SourcePixels, Is.SameAs(sourcePixels));
+        Assert.That(info.SourcePixels, Is.Not.SameAs(pixels));
+    }
+
+    [Test]
+    public void Constructor_WithInit_WithoutSourcePixels_SetsSourcePixelsToPixels()
+    {
+        var pixels = Picture.CreateEmpty(new PictureSize(10, 10));
+        var position = new Position(5, 5);
+        var sourcePixels = Picture.CreateEmpty(new PictureSize(20, 20));
+
+        var info = new SelectionPreviewInfo(pixels, position)
+        {
+            SourcePixels = sourcePixels
+        };
+
+        Assert.That(info.SourcePixels, Is.SameAs(sourcePixels));
+        Assert.That(info.SourcePixels, Is.Not.SameAs(pixels));
+    }
+
+    [Test]
+    public void Constructor_WithCopy_WithoutSourcePixels_SetsSourcePixelsToPixels()
+    {
+        var pixels = Picture.CreateEmpty(new PictureSize(10, 10));
+        var position = new Position(5, 5);
+
+        var info = new SelectionPreviewInfo(pixels, position);
+        var info2 = info with { Position = new Position(10, 10) };
+
+        Assert.That(info2.SourcePixels, Is.SameAs(pixels));
+        Assert.That(info2.Position, Is.EqualTo(new Position(10, 10)));
+    }
+}


### PR DESCRIPTION
🎯 **What:** The missing tests for `SelectionPreviewInfo` in `Eede.Domain`.
📊 **Coverage:** Added test cases covering default fallback to `Pixels` if `SourcePixels` is null, explicit `SourcePixels` assignment via constructor, object initialization (`init`), and record copy (`with`) functionality.
✨ **Result:** Improved confidence in domain object construction with deterministic test logic verified by NUnit.

---
*PR created automatically by Jules for task [9531142479281571672](https://jules.google.com/task/9531142479281571672) started by @arkfinn*