### PR TITLE
🧪 Add tests for SelectionPreviewInfo SourcePixels initialization

### DIFF
--- a/Eede.Domain.Tests/ImageEditing/SelectionPreviewInfoTests.cs
+++ b/Eede.Domain.Tests/ImageEditing/SelectionPreviewInfoTests.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+using Eede.Domain.ImageEditing;
+using Eede.Domain.SharedKernel;
+
+namespace Eede.Domain.Tests.ImageEditing;
+
+[TestFixture]
+public class SelectionPreviewInfoTests
+{
+    [Test]
+    public void Constructor_WithoutSourcePixels_SetsSourcePixelsToPixels()
+    {
+        // Arrange
+        var pixels = Picture.CreateEmpty(new PictureSize(10, 10));
+        var position = new Position(5, 5);
+
+        // Act
+        var info = new SelectionPreviewInfo(pixels, position);
+
+        // Assert
+        Assert.That(info.SourcePixels, Is.SameAs(pixels));
+    }
+
+    [Test]
+    public void Constructor_WithSourcePixels_SetsSourcePixelsToProvidedValue()
+    {
+        // Arrange
+        var pixels = Picture.CreateEmpty(new PictureSize(10, 10));
+        var sourcePixels = Picture.CreateEmpty(new PictureSize(20, 20));
+        var position = new Position(5, 5);
+
+        // Act
+        var info = new SelectionPreviewInfo(pixels, position, SourcePixels: sourcePixels);
+
+        // Assert
+        Assert.That(info.SourcePixels, Is.SameAs(sourcePixels));
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `SourcePixels` property initialization logic in `SelectionPreviewInfo` was previously untested. This PR adds unit tests to ensure `SourcePixels` correctly defaults to `Pixels` if omitted and retains the provided value when explicitly passed.
📊 **Coverage:** Two scenarios are now tested:
- `Constructor_WithoutSourcePixels_SetsSourcePixelsToPixels`
- `Constructor_WithSourcePixels_SetsSourcePixelsToProvidedValue`
✨ **Result:** Increased test coverage and confidence in the record initialization behavior.

---
*PR created automatically by Jules for task [12884961246428936453](https://jules.google.com/task/12884961246428936453) started by @arkfinn*