### PR TITLE
🔒 Fix Potential Command Injection in ExternalBrowserService.OpenUrl

### DIFF
--- a/Eede.Infrastructure.Tests/Services/ExternalBrowserServiceTests.cs
+++ b/Eede.Infrastructure.Tests/Services/ExternalBrowserServiceTests.cs
@@ -1,0 +1,51 @@
+using System;
+using Eede.Infrastructure.Services;
+using NUnit.Framework;
+
+namespace Eede.Infrastructure.Tests.Services;
+
+[TestFixture]
+public class ExternalBrowserServiceTests
+{
+    private ExternalBrowserService _service;
+
+    [SetUp]
+    public void Setup()
+    {
+        _service = new ExternalBrowserService();
+    }
+
+    [TestCase("http://example.com")]
+    [TestCase("https://example.com")]
+    public void OpenUrl_ShouldNotThrow_WhenUrlIsSafe(string url)
+    {
+        // We can't easily verify Process.Start actually ran in this environment,
+        // but we can verify it doesn't throw a validation exception for safe URLs.
+        // If Process.Start fails due to environment (no browser), it might throw,
+        // so we'll just check it doesn't throw our ArgumentException.
+        try
+        {
+            _service.OpenUrl(url);
+        }
+        catch (ArgumentException ex)
+        {
+            Assert.Fail($"Should not throw ArgumentException for safe URL: {url}. Error: {ex.Message}");
+        }
+        catch (Exception)
+        {
+            // Other exceptions (like Process.Start failing in Linux) are acceptable here
+            // as we are testing the validation logic.
+        }
+    }
+
+    [TestCase("file:///C:/Windows/System32/calc.exe")]
+    [TestCase("ftp://example.com")]
+    [TestCase("javascript:alert(1)")]
+    [TestCase("C:\\Windows\\System32\\calc.exe")]
+    [TestCase("/etc/passwd")]
+    public void OpenUrl_ShouldThrowArgumentException_WhenUrlIsUnsafe(string url)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => _service.OpenUrl(url));
+        Assert.That(ex.Message, Does.Contain("Invalid URL scheme"));
+    }
+}

--- a/Eede.Infrastructure/Services/ExternalBrowserService.cs
+++ b/Eede.Infrastructure/Services/ExternalBrowserService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using Eede.Application.Infrastructure;
 
@@ -7,6 +8,12 @@ public class ExternalBrowserService : IExternalBrowserService
 {
     public void OpenUrl(string url)
     {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ArgumentException("Invalid URL scheme. Only http and https are allowed.", nameof(url));
+        }
+
         Process.Start(new ProcessStartInfo
         {
             FileName = url,


### PR DESCRIPTION
Implemented URL scheme validation in `ExternalBrowserService.OpenUrl` to restrict input to `http://` and `https://` schemes, mitigating potential command injection risks. Added unit tests for both valid and invalid URL scenarios.

---
*PR created automatically by Jules for task [7610135774641149671](https://jules.google.com/task/7610135774641149671) started by @arkfinn*