### PR TITLE
🧪 Add tests for RecentFile

### DIFF
--- a/Eede.Application.Tests/Settings/RecentFileTests.cs
+++ b/Eede.Application.Tests/Settings/RecentFileTests.cs
@@ -1,0 +1,43 @@
+using Eede.Application.Settings;
+using NUnit.Framework;
+using System;
+
+namespace Eede.Application.Tests.Settings
+{
+    [TestFixture]
+    public class RecentFileTests
+    {
+        [Test]
+        public void DefaultConstructor_SetsExpectedDefaultValues()
+        {
+            var recentFile = new RecentFile();
+
+            Assert.That(recentFile.Path, Is.EqualTo(string.Empty));
+            Assert.That(recentFile.LastAccessed, Is.EqualTo(default(DateTime)));
+        }
+
+        [Test]
+        public void PathProperty_CanBeSetAndRetrieved()
+        {
+            var expectedPath = "/some/test/path.png";
+            var recentFile = new RecentFile
+            {
+                Path = expectedPath
+            };
+
+            Assert.That(recentFile.Path, Is.EqualTo(expectedPath));
+        }
+
+        [Test]
+        public void LastAccessedProperty_CanBeSetAndRetrieved()
+        {
+            var expectedDate = new DateTime(2023, 10, 25, 12, 34, 56);
+            var recentFile = new RecentFile
+            {
+                LastAccessed = expectedDate
+            };
+
+            Assert.That(recentFile.LastAccessed, Is.EqualTo(expectedDate));
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `RecentFile` data class located in `Eede.Application/Settings/RecentFile.cs`.
📊 **Coverage:** Covered the default constructor initialization, ensuring empty values are set correctly, and added tests for setting/getting both `Path` and `LastAccessed` properties.
✨ **Result:** Improved test coverage and reliability for application settings by ensuring the `RecentFile` data class behaves as expected.

---
*PR created automatically by Jules for task [8527240301442430878](https://jules.google.com/task/8527240301442430878) started by @arkfinn*