### PR TITLE
🔒 [security fix] surface silent failures in JsonSettingsRepository

### DIFF
--- a/Eede.Infrastructure/Settings/JsonSettingsRepository.cs
+++ b/Eede.Infrastructure/Settings/JsonSettingsRepository.cs
@@ -27,8 +27,9 @@ public class JsonSettingsRepository : ISettingsRepository
             using var stream = File.OpenRead(_filePath);
             return await JsonSerializer.DeserializeAsync<AppSettings>(stream) ?? new AppSettings { GridWidth = 32, GridHeight = 32 };
         }
-        catch
+        catch (System.Exception ex)
         {
+            System.Diagnostics.Trace.WriteLine(ex);
             return new AppSettings { GridWidth = 32, GridHeight = 32 };
         }
     }
@@ -46,9 +47,10 @@ public class JsonSettingsRepository : ISettingsRepository
             using var stream = File.Create(_filePath);
             await JsonSerializer.SerializeAsync(stream, settings);
         }
-        catch
+        catch (System.Exception ex)
         {
             // 保存失敗してもアプリケーションが続行できるように例外を飲み込む
+            System.Diagnostics.Trace.WriteLine(ex);
         }
     }
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was a silent failure in `JsonSettingsRepository.SaveAsync` and `LoadAsync` where exceptions were swallowed without any logging or notification.

⚠️ **Risk:** If settings fail to save or load due to permissions, file corruption, or other I/O issues, the user would be unaware. This could lead to loss of configuration data or confusing application behavior without any diagnostic information available to troubleshoot the root cause.

🛡️ **Solution:** Modified the `catch` blocks in `JsonSettingsRepository` to catch `System.Exception` and log the exception details using `System.Diagnostics.Trace.WriteLine(ex)`. `Trace` was chosen because the application is already configured to log to trace in its desktop entry point, and unlike `Debug`, it persists in production Release builds, ensuring that field errors can be diagnosed.

---
*PR created automatically by Jules for task [12887645812299150680](https://jules.google.com/task/12887645812299150680) started by @arkfinn*