### PR TITLE
⚡ Batch blending optimization for Undo/Redo

### DIFF
--- a/Eede.Domain.Tests/ImageEditing/DrawingSessionBenchmark.cs
+++ b/Eede.Domain.Tests/ImageEditing/DrawingSessionBenchmark.cs
@@ -1,0 +1,55 @@
+using Eede.Domain.ImageEditing;
+using Eede.Domain.SharedKernel;
+using Eede.Domain.ImageEditing.Blending;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Eede.Domain.Tests.ImageEditing;
+
+[TestFixture]
+public class DrawingSessionBenchmark
+{
+    [Test]
+    public void BenchmarkUndoRedoDiffs()
+    {
+        int width = 100;
+        int height = 100;
+        var initialPixels = new byte[width * height * 4];
+        var initialPicture = Picture.Create(new PictureSize(width, height), initialPixels);
+        var session = new DrawingSession(initialPicture);
+
+        int diffCount = 100;
+        var diffs = new List<PictureDiff>();
+        Random rand = new Random(42);
+
+        for (int i = 0; i < diffCount; i++)
+        {
+            int x = rand.Next(0, width - 10);
+            int y = rand.Next(0, height - 10);
+            var area = new PictureArea(new Position(x, y), new PictureSize(10, 10));
+            var before = Picture.CreateEmpty(area.Size);
+            var after = Picture.CreateEmpty(area.Size);
+            diffs.Add(new PictureDiff(area, before, after));
+        }
+
+        var region = new PictureRegion(diffs.Select(d => d.Area));
+        var nextPicture = initialPicture;
+        var sessionWithDiffs = session.PushDiff(nextPicture, region);
+
+        int iterations = 1;
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        for (int i = 0; i < iterations; i++)
+        {
+            var result = sessionWithDiffs.Undo();
+            var redoResult = result.Session.Redo();
+        }
+        sw.Stop();
+
+        Console.WriteLine($"Total time for {iterations} Undo/Redo with {diffCount} diffs: {sw.ElapsedMilliseconds}ms");
+    }
+}

--- a/Eede.Domain/ImageEditing/Blending/AlphaImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/AlphaImageBlender.cs
@@ -14,7 +14,22 @@ public class AlphaImageBlender : IImageBlender
     public Picture Blend(Picture from, Picture to, Position toPosition)
     {
         byte[] toPixels = to.CloneImage();
+        BlendInternal(from, to, toPosition, toPixels);
+        return Picture.Create(to.Size, toPixels);
+    }
 
+    public Picture Blend(System.Collections.Generic.IEnumerable<(Picture Picture, Position Position)> sources, Picture destination)
+    {
+        byte[] toPixels = destination.CloneImage();
+        foreach (var source in sources)
+        {
+            BlendInternal(source.Picture, destination, source.Position, toPixels);
+        }
+        return Picture.Create(destination.Size, toPixels);
+    }
+
+    private void BlendInternal(Picture from, Picture to, Position toPosition, byte[] toPixels)
+    {
         int startY = Math.Max(0, toPosition.Y);
         int startX = Math.Max(0, toPosition.X);
         int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
@@ -59,7 +74,5 @@ public class AlphaImageBlender : IImageBlender
                 toPixels[toPos + 2] = (byte)decimal.Add(decimal.Divide((toPixels[toPos + 2] * blendedAlpha) + (fromSpan[fromPos + 2] * fromAlpha), alpha), 0.5m);
             }
         }
-
-        return Picture.Create(to.Size, toPixels);
     }
 }

--- a/Eede.Domain/ImageEditing/Blending/AlphaOnlyImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/AlphaOnlyImageBlender.cs
@@ -14,7 +14,22 @@ public class AlphaOnlyImageBlender : IImageBlender
     public Picture Blend(Picture from, Picture to, Position toPosition)
     {
         byte[] toPixels = to.CloneImage();
+        BlendInternal(from, to, toPosition, toPixels);
+        return Picture.Create(to.Size, toPixels);
+    }
 
+    public Picture Blend(System.Collections.Generic.IEnumerable<(Picture Picture, Position Position)> sources, Picture destination)
+    {
+        byte[] toPixels = destination.CloneImage();
+        foreach (var source in sources)
+        {
+            BlendInternal(source.Picture, destination, source.Position, toPixels);
+        }
+        return Picture.Create(destination.Size, toPixels);
+    }
+
+    private void BlendInternal(Picture from, Picture to, Position toPosition, byte[] toPixels)
+    {
         int startY = Math.Max(0, toPosition.Y);
         int startX = Math.Max(0, toPosition.X);
         int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
@@ -30,6 +45,5 @@ public class AlphaOnlyImageBlender : IImageBlender
                 toPixels[toPos + 3] = from.AsSpan()[fromPos + 3];
             }
         }
-        return Picture.Create(to.Size, toPixels);
     }
 }

--- a/Eede.Domain/ImageEditing/Blending/DirectImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/DirectImageBlender.cs
@@ -14,7 +14,22 @@ public class DirectImageBlender : IImageBlender
     public Picture Blend(Picture from, Picture to, Position toPosition)
     {
         byte[] toPixels = to.CloneImage();
+        BlendInternal(from, to, toPosition, toPixels);
+        return Picture.Create(to.Size, toPixels);
+    }
 
+    public Picture Blend(System.Collections.Generic.IEnumerable<(Picture Picture, Position Position)> sources, Picture destination)
+    {
+        byte[] toPixels = destination.CloneImage();
+        foreach (var source in sources)
+        {
+            BlendInternal(source.Picture, destination, source.Position, toPixels);
+        }
+        return Picture.Create(destination.Size, toPixels);
+    }
+
+    private void BlendInternal(Picture from, Picture to, Position toPosition, byte[] toPixels)
+    {
         int startY = Math.Max(0, toPosition.Y);
         int startX = Math.Max(0, toPosition.X);
         int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
@@ -33,6 +48,5 @@ public class DirectImageBlender : IImageBlender
                 toPixels[toPos + 3] = fromSpan[fromPos + 3];
             }
         }
-        return Picture.Create(to.Size, toPixels);
     }
 }

--- a/Eede.Domain/ImageEditing/Blending/IImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/IImageBlender.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using Eede.Domain.SharedKernel;
+using System.Collections.Generic;
 
 namespace Eede.Domain.ImageEditing.Blending;
 
@@ -8,4 +9,6 @@ public interface IImageBlender
     Picture Blend(Picture from, Picture to);
 
     Picture Blend(Picture from, Picture to, Position toPosition);
+
+    Picture Blend(IEnumerable<(Picture Picture, Position Position)> sources, Picture destination);
 }

--- a/Eede.Domain/ImageEditing/Blending/RGBOnlyImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/RGBOnlyImageBlender.cs
@@ -14,7 +14,22 @@ public class RGBOnlyImageBlender : IImageBlender
     public Picture Blend(Picture from, Picture to, Position toPosition)
     {
         byte[] toPixels = to.CloneImage();
+        BlendInternal(from, to, toPosition, toPixels);
+        return Picture.Create(to.Size, toPixels);
+    }
 
+    public Picture Blend(System.Collections.Generic.IEnumerable<(Picture Picture, Position Position)> sources, Picture destination)
+    {
+        byte[] toPixels = destination.CloneImage();
+        foreach (var source in sources)
+        {
+            BlendInternal(source.Picture, destination, source.Position, toPixels);
+        }
+        return Picture.Create(destination.Size, toPixels);
+    }
+
+    private void BlendInternal(Picture from, Picture to, Position toPosition, byte[] toPixels)
+    {
         int startY = Math.Max(0, toPosition.Y);
         int startX = Math.Max(0, toPosition.X);
         int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
@@ -33,7 +48,5 @@ public class RGBOnlyImageBlender : IImageBlender
                 toPixels[toPos + 2] = fromSpan[fromPos + 2];
             }
         }
-
-        return Picture.Create(to.Size, toPixels);
     }
 }

--- a/Eede.Domain/ImageEditing/DrawingSession.cs
+++ b/Eede.Domain/ImageEditing/DrawingSession.cs
@@ -211,11 +211,7 @@ namespace Eede.Domain.ImageEditing
             }
             else if (historyItem is DiffHistoryItem diffItem)
             {
-                var restoredPicture = Buffer.Previous;
-                foreach (var diff in diffItem.Diffs)
-                {
-                    restoredPicture = restoredPicture.Blend(new DirectImageBlender(), diff.Before, diff.Area.Position);
-                }
+                var restoredPicture = Buffer.Previous.Blend(new DirectImageBlender(), diffItem.Diffs.Select(d => (d.Before, d.Area.Position)));
                 var nextSession = new DrawingSession(
                     new DrawingBuffer(restoredPicture),
                     diffItem.SelectingArea,
@@ -260,11 +256,7 @@ namespace Eede.Domain.ImageEditing
             }
             else if (historyItem is DiffHistoryItem diffItem)
             {
-                var restoredPicture = Buffer.Previous;
-                foreach (var diff in diffItem.Diffs)
-                {
-                    restoredPicture = restoredPicture.Blend(new DirectImageBlender(), diff.Before, diff.Area.Position);
-                }
+                var restoredPicture = Buffer.Previous.Blend(new DirectImageBlender(), diffItem.Diffs.Select(d => (d.Before, d.Area.Position)));
                 var nextSession = new DrawingSession(
                     new DrawingBuffer(restoredPicture),
                     diffItem.SelectingArea,

--- a/Eede.Domain/ImageEditing/Picture.cs
+++ b/Eede.Domain/ImageEditing/Picture.cs
@@ -106,6 +106,11 @@ public record Picture
         return blender.Blend(src, this, toPosition);
     }
 
+    public Picture Blend(IImageBlender blender, System.Collections.Generic.IEnumerable<(Picture Picture, Position Position)> sources)
+    {
+        return blender.Blend(sources, this);
+    }
+
     public Picture Draw(Func<Picture, Picture> function, IImageBlender blender)
     {
         Picture data = function(this);


### PR DESCRIPTION
💡 **What:**
Implemented a batched blending optimization in the `DrawingSession` class for `Undo` and `Redo` operations. This involved:
- Extending the `IImageBlender` interface with a batch `Blend` method.
- Refactoring all `IImageBlender` implementations (`DirectImageBlender`, `AlphaImageBlender`, `AlphaOnlyImageBlender`, `RGBOnlyImageBlender`) to support applying multiple source pictures to a single destination buffer.
- Adding a batch `Blend` helper to the `Picture` record.
- Replacing iterative `Blend` calls in `DrawingSession.cs` with a single batch call.

🎯 **Why:**
In the original implementation, `Undo` and `Redo` operations for `DiffHistoryItem` looped through a list of diffs and called `Picture.Blend` for each one. Since each `Blend` call creates a full clone of the image, a large number of diffs (common in tools like the free-hand brush) led to significant performance degradation and excessive memory allocations.

📊 **Measured Improvement:**
While environment timeouts prevented formal benchmark execution, the optimization reduces the number of full-image clones from O(N) to O(1) per `Undo`/`Redo` operation, where N is the number of diffs. For a history item with hundreds of diffs, this represents a substantial reduction in both CPU time and memory pressure.

---
*PR created automatically by Jules for task [16952817558241004718](https://jules.google.com/task/16952817558241004718) started by @arkfinn*