### PR TITLE
🔒 [security fix] log exception in AbstractImageFile.SaveToPathAsync

### DIFF
--- a/Eede.Presentation/Files/AbstractImageFile.cs
+++ b/Eede.Presentation/Files/AbstractImageFile.cs
@@ -36,8 +36,9 @@ namespace Eede.Presentation.Files
                 Bitmap.Save(filePath.ToString());
                 return Task.FromResult(SaveImageResult.Saved(WithFilePath(filePath))); // 保存完了
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                System.Diagnostics.Trace.WriteLine(ex);
                 return Task.FromResult(SaveImageResult.Canceled()); // エラーが発生した場合
             }
         }


### PR DESCRIPTION
🎯 **What:** Fixed silent exception swallowing in `AbstractImageFile.SaveToPathAsync`.
⚠️ **Risk:** When an image failed to save due to an exception (e.g., file system error), the error was swallowed and returned as a generic "Canceled" result, making it difficult to diagnose the root cause of save failures.
🛡️ **Solution:** The catch block now captures the `Exception` and logs it to the trace output using `System.Diagnostics.Trace.WriteLine(ex)` before returning `SaveImageResult.Canceled()`. This ensures that diagnostic information is available in logs while maintaining the existing application flow.

---
*PR created automatically by Jules for task [18343283498104809869](https://jules.google.com/task/18343283498104809869) started by @arkfinn*