### PR TITLE
⚡ optimize IImageBlender by lifting AsSpan() out of loops

### DIFF
--- a/Eede.Domain/ImageEditing/Blending/AlphaImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/AlphaImageBlender.cs
@@ -20,6 +20,7 @@ public class AlphaImageBlender : IImageBlender
         int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
         int maxX = Math.Min(toPosition.X + from.Width, to.Width);
 
+        ReadOnlySpan<byte> fromSpan = from.AsSpan();
         for (int y = startY; y < maxY; y++)
         {
             for (int x = startX; x < maxX; x++)
@@ -28,7 +29,6 @@ public class AlphaImageBlender : IImageBlender
                 int fromPos = ((x - toPosition.X) * 4) + (from.Stride * (y - toPosition.Y));
 
                 // 転送元がアルファ0なら転送しない
-                ReadOnlySpan<byte> fromSpan = from.AsSpan();
                 byte fromA = fromSpan[fromPos + 3];
                 if (fromA == 0)
                 {

--- a/Eede.Domain/ImageEditing/Blending/AlphaOnlyImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/AlphaOnlyImageBlender.cs
@@ -20,6 +20,7 @@ public class AlphaOnlyImageBlender : IImageBlender
         int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
         int maxX = Math.Min(toPosition.X + from.Width, to.Width);
 
+        ReadOnlySpan<byte> fromSpan = from.AsSpan();
         for (int y = startY; y < maxY; y++)
         {
             for (int x = startX; x < maxX; x++)
@@ -27,7 +28,7 @@ public class AlphaOnlyImageBlender : IImageBlender
                 int toPos = (x * 4) + (to.Stride * y);
                 int fromPos = ((x - toPosition.X) * 4) + (from.Stride * (y - toPosition.Y));
 
-                toPixels[toPos + 3] = from.AsSpan()[fromPos + 3];
+                toPixels[toPos + 3] = fromSpan[fromPos + 3];
             }
         }
         return Picture.Create(to.Size, toPixels);

--- a/Eede.Domain/ImageEditing/Blending/RGBOnlyImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/RGBOnlyImageBlender.cs
@@ -20,6 +20,7 @@ public class RGBOnlyImageBlender : IImageBlender
         int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
         int maxX = Math.Min(toPosition.X + from.Width, to.Width);
 
+        ReadOnlySpan<byte> fromSpan = from.AsSpan();
         for (int y = startY; y < maxY; y++)
         {
             for (int x = startX; x < maxX; x++)
@@ -27,7 +28,6 @@ public class RGBOnlyImageBlender : IImageBlender
                 int toPos = (x * 4) + (to.Stride * y);
                 int fromPos = ((x - toPosition.X) * 4) + (from.Stride * (y - toPosition.Y));
 
-                ReadOnlySpan<byte> fromSpan = from.AsSpan();
                 toPixels[toPos + 0] = fromSpan[fromPos + 0];
                 toPixels[toPos + 1] = fromSpan[fromPos + 1];
                 toPixels[toPos + 2] = fromSpan[fromPos + 2];


### PR DESCRIPTION
💡 **What:** Moved `AsSpan()` calls outside of the nested pixel iteration loops in `RGBOnlyImageBlender`, `AlphaOnlyImageBlender`, and `AlphaImageBlender`.

🎯 **Why:** Calling `AsSpan()` for every pixel (or multiple times per pixel) in a large image operation introduces significant overhead. By lifting it out of the loops, we ensure it's called once per `Blend` operation, making the code more efficient.

📊 **Measured Improvement:** Direct performance measurement was impractical due to persistent environment timeouts during build/test operations. However, this is a clear micro-optimization for a high-frequency code path (millions of calls per image operation), following the established pattern in `DirectImageBlender`. Correctness was verified via code review and manual inspection of the logic.

---
*PR created automatically by Jules for task [11813626719724279549](https://jules.google.com/task/11813626719724279549) started by @arkfinn*