### PR TITLE
🧪 [Testing Improvement] Add tests for DrawingSessionProvider Update method

### DIFF
--- a/Eede.Tests/Application/Pictures/DrawingSessionProviderTests.cs
+++ b/Eede.Tests/Application/Pictures/DrawingSessionProviderTests.cs
@@ -1,0 +1,35 @@
+using Eede.Application.Pictures;
+using Eede.Domain.ImageEditing;
+using Eede.Domain.SharedKernel;
+using NUnit.Framework;
+
+namespace Eede.Application.Tests.Pictures
+{
+    public class DrawingSessionProviderTests
+    {
+        [Test]
+        public void Update_ShouldUpdateCurrentSession()
+        {
+            var provider = new DrawingSessionProvider();
+            var newSession = new DrawingSession(Picture.CreateEmpty(new PictureSize(16, 16)));
+
+            provider.Update(newSession);
+
+            Assert.That(provider.CurrentSession, Is.SameAs(newSession));
+        }
+
+        [Test]
+        public void Update_ShouldFireSessionChangedEvent()
+        {
+            var provider = new DrawingSessionProvider();
+            var newSession = new DrawingSession(Picture.CreateEmpty(new PictureSize(16, 16)));
+
+            DrawingSession? eventSession = null;
+            provider.SessionChanged += (s) => eventSession = s;
+
+            provider.Update(newSession);
+
+            Assert.That(eventSession, Is.SameAs(newSession));
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing test coverage for the `Update` method of `DrawingSessionProvider` within the Application layer.
📊 **Coverage:** Scenarios covered include verifying that `Update` correctly assigns the `CurrentSession` and correctly triggers the `SessionChanged` event with the updated session instance.
✨ **Result:** Test coverage for `DrawingSessionProvider` has improved, ensuring future state mutations trigger expected UI updates without regressions.

---
*PR created automatically by Jules for task [14864173275405055961](https://jules.google.com/task/14864173275405055961) started by @arkfinn*