### PR TITLE
🧹 Extracted duplicated ImageBlender logic into base class

### DIFF
--- a/Eede.Domain/ImageEditing/Blending/AlphaImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/AlphaImageBlender.cs
@@ -1,66 +1,44 @@
-﻿#nullable enable
-using Eede.Domain.SharedKernel;
+#nullable enable
 using System;
 
 namespace Eede.Domain.ImageEditing.Blending;
 
-public class AlphaImageBlender : IImageBlender
+public class AlphaImageBlender : ImageBlenderBase
 {
-    public Picture Blend(Picture from, Picture to)
+    protected override void BlendInternal(ReadOnlySpan<byte> fromSpan, byte[] toPixels, int fromPos, int toPos)
     {
-        return Blend(from, to, new Position(0, 0));
-    }
-
-    public Picture Blend(Picture from, Picture to, Position toPosition)
-    {
-        byte[] toPixels = to.CloneImage();
-
-        int startY = Math.Max(0, toPosition.Y);
-        int startX = Math.Max(0, toPosition.X);
-        int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
-        int maxX = Math.Min(toPosition.X + from.Width, to.Width);
-        ReadOnlySpan<byte> fromSpan = from.AsSpan();
-
-        for (int y = startY; y < maxY; y++)
+        // 転送元がアルファ0なら転送しない
+        byte fromA = fromSpan[fromPos + 3];
+        if (fromA == 0)
         {
-            for (int x = startX; x < maxX; x++)
-            {
-                int toPos = (x * 4) + (to.Stride * y);
-                int fromPos = ((x - toPosition.X) * 4) + (from.Stride * (y - toPosition.Y));
-
-                // 転送元がアルファ0なら転送しない
-
-                byte fromA = fromSpan[fromPos + 3];
-                if (fromA == 0)
-                {
-                    continue;
-                }
-                // 転送先がアルファ0なら無条件で転送
-                byte toA = toPixels[toPos + 3];
-                if (toA == 0)
-                {
-                    toPixels[toPos + 0] = fromSpan[fromPos + 0];
-                    toPixels[toPos + 1] = fromSpan[fromPos + 1];
-                    toPixels[toPos + 2] = fromSpan[fromPos + 2];
-                    toPixels[toPos + 3] = fromA;
-                    continue;
-                }
-                // それ以外の場合、アルファ値・カラーを合成する
-                decimal fromAlpha = decimal.Divide(fromA, 255);
-                decimal toAlpha = decimal.Divide(toA, 255);
-                decimal alpha = fromAlpha + toAlpha - (fromAlpha * toAlpha);
-                toPixels[toPos + 3] = (byte)decimal.Add(decimal.Multiply(alpha, 255), 0.5m);
-                if (alpha == 0)
-                {
-                    continue;
-                }
-                decimal blendedAlpha = toAlpha * (1 - fromAlpha);
-                toPixels[toPos + 0] = (byte)decimal.Add(decimal.Divide((toPixels[toPos + 0] * blendedAlpha) + (fromSpan[fromPos + 0] * fromAlpha), alpha), 0.5m);
-                toPixels[toPos + 1] = (byte)decimal.Add(decimal.Divide((toPixels[toPos + 1] * blendedAlpha) + (fromSpan[fromPos + 1] * fromAlpha), alpha), 0.5m);
-                toPixels[toPos + 2] = (byte)decimal.Add(decimal.Divide((toPixels[toPos + 2] * blendedAlpha) + (fromSpan[fromPos + 2] * fromAlpha), alpha), 0.5m);
-            }
+            return;
         }
 
-        return Picture.Create(to.Size, toPixels);
+        // 転送先がアルファ0なら無条件で転送
+        byte toA = toPixels[toPos + 3];
+        if (toA == 0)
+        {
+            toPixels[toPos + 0] = fromSpan[fromPos + 0];
+            toPixels[toPos + 1] = fromSpan[fromPos + 1];
+            toPixels[toPos + 2] = fromSpan[fromPos + 2];
+            toPixels[toPos + 3] = fromA;
+            return;
+        }
+
+        // それ以外の場合、アルファ値・カラーを合成する
+        decimal fromAlpha = decimal.Divide(fromA, 255);
+        decimal toAlpha = decimal.Divide(toA, 255);
+        decimal alpha = fromAlpha + toAlpha - (fromAlpha * toAlpha);
+        toPixels[toPos + 3] = (byte)decimal.Add(decimal.Multiply(alpha, 255), 0.5m);
+
+        if (alpha == 0)
+        {
+            return;
+        }
+
+        decimal blendedAlpha = toAlpha * (1 - fromAlpha);
+        toPixels[toPos + 0] = (byte)decimal.Add(decimal.Divide((toPixels[toPos + 0] * blendedAlpha) + (fromSpan[fromPos + 0] * fromAlpha), alpha), 0.5m);
+        toPixels[toPos + 1] = (byte)decimal.Add(decimal.Divide((toPixels[toPos + 1] * blendedAlpha) + (fromSpan[fromPos + 1] * fromAlpha), alpha), 0.5m);
+        toPixels[toPos + 2] = (byte)decimal.Add(decimal.Divide((toPixels[toPos + 2] * blendedAlpha) + (fromSpan[fromPos + 2] * fromAlpha), alpha), 0.5m);
     }
 }

--- a/Eede.Domain/ImageEditing/Blending/AlphaOnlyImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/AlphaOnlyImageBlender.cs
@@ -1,36 +1,12 @@
-﻿#nullable enable
-using Eede.Domain.SharedKernel;
+#nullable enable
 using System;
 
 namespace Eede.Domain.ImageEditing.Blending;
 
-public class AlphaOnlyImageBlender : IImageBlender
+public class AlphaOnlyImageBlender : ImageBlenderBase
 {
-    public Picture Blend(Picture from, Picture to)
+    protected override void BlendInternal(ReadOnlySpan<byte> fromSpan, byte[] toPixels, int fromPos, int toPos)
     {
-        return Blend(from, to, new Position(0, 0));
-    }
-
-    public Picture Blend(Picture from, Picture to, Position toPosition)
-    {
-        byte[] toPixels = to.CloneImage();
-
-        int startY = Math.Max(0, toPosition.Y);
-        int startX = Math.Max(0, toPosition.X);
-        int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
-        int maxX = Math.Min(toPosition.X + from.Width, to.Width);
-
-        ReadOnlySpan<byte> fromSpan = from.AsSpan();
-        for (int y = startY; y < maxY; y++)
-        {
-            for (int x = startX; x < maxX; x++)
-            {
-                int toPos = (x * 4) + (to.Stride * y);
-                int fromPos = ((x - toPosition.X) * 4) + (from.Stride * (y - toPosition.Y));
-
-                toPixels[toPos + 3] = fromSpan[fromPos + 3];
-            }
-        }
-        return Picture.Create(to.Size, toPixels);
+        toPixels[toPos + 3] = fromSpan[fromPos + 3];
     }
 }

--- a/Eede.Domain/ImageEditing/Blending/DirectImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/DirectImageBlender.cs
@@ -1,40 +1,15 @@
 #nullable enable
-using Eede.Domain.SharedKernel;
 using System;
 
 namespace Eede.Domain.ImageEditing.Blending;
 
-public class DirectImageBlender : IImageBlender
+public class DirectImageBlender : ImageBlenderBase
 {
-    public Picture Blend(Picture from, Picture to)
+    protected override void BlendInternal(ReadOnlySpan<byte> fromSpan, byte[] toPixels, int fromPos, int toPos)
     {
-        return Blend(from, to, new Position(0, 0));
-    }
-
-    public Picture Blend(Picture from, Picture to, Position toPosition)
-    {
-        byte[] toPixels = to.CloneImage();
-
-        int startY = Math.Max(0, toPosition.Y);
-        int startX = Math.Max(0, toPosition.X);
-        int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
-        int maxX = Math.Min(toPosition.X + from.Width, to.Width);
-
-        ReadOnlySpan<byte> fromSpan = from.AsSpan();
-        for (int y = startY; y < maxY; y++)
-        {
-            int toPos = (startX * 4) + (to.Stride * y);
-            int fromPos = ((startX - toPosition.X) * 4) + (from.Stride * (y - toPosition.Y));
-            for (int x = startX; x < maxX; x++)
-            {
-                toPixels[toPos + 0] = fromSpan[fromPos + 0];
-                toPixels[toPos + 1] = fromSpan[fromPos + 1];
-                toPixels[toPos + 2] = fromSpan[fromPos + 2];
-                toPixels[toPos + 3] = fromSpan[fromPos + 3];
-                toPos += 4;
-                fromPos += 4;
-            }
-        }
-        return Picture.Create(to.Size, toPixels);
+        toPixels[toPos + 0] = fromSpan[fromPos + 0];
+        toPixels[toPos + 1] = fromSpan[fromPos + 1];
+        toPixels[toPos + 2] = fromSpan[fromPos + 2];
+        toPixels[toPos + 3] = fromSpan[fromPos + 3];
     }
 }

--- a/Eede.Domain/ImageEditing/Blending/ImageBlenderBase.cs
+++ b/Eede.Domain/ImageEditing/Blending/ImageBlenderBase.cs
@@ -1,0 +1,41 @@
+#nullable enable
+using Eede.Domain.SharedKernel;
+using System;
+
+namespace Eede.Domain.ImageEditing.Blending;
+
+public abstract class ImageBlenderBase : IImageBlender
+{
+    public Picture Blend(Picture from, Picture to)
+    {
+        return Blend(from, to, new Position(0, 0));
+    }
+
+    public Picture Blend(Picture from, Picture to, Position toPosition)
+    {
+        byte[] toPixels = to.CloneImage();
+
+        int startY = Math.Max(0, toPosition.Y);
+        int startX = Math.Max(0, toPosition.X);
+        int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
+        int maxX = Math.Min(toPosition.X + from.Width, to.Width);
+
+        ReadOnlySpan<byte> fromSpan = from.AsSpan();
+
+        for (int y = startY; y < maxY; y++)
+        {
+            int toPos = (startX * 4) + (to.Stride * y);
+            int fromPos = ((startX - toPosition.X) * 4) + (from.Stride * (y - toPosition.Y));
+
+            for (int x = startX; x < maxX; x++)
+            {
+                BlendInternal(fromSpan, toPixels, fromPos, toPos);
+                toPos += 4;
+                fromPos += 4;
+            }
+        }
+        return Picture.Create(to.Size, toPixels);
+    }
+
+    protected abstract void BlendInternal(ReadOnlySpan<byte> fromSpan, byte[] toPixels, int fromPos, int toPos);
+}

--- a/Eede.Domain/ImageEditing/Blending/RGBOnlyImageBlender.cs
+++ b/Eede.Domain/ImageEditing/Blending/RGBOnlyImageBlender.cs
@@ -1,39 +1,14 @@
-﻿#nullable enable
-using Eede.Domain.SharedKernel;
+#nullable enable
 using System;
 
 namespace Eede.Domain.ImageEditing.Blending;
 
-public class RGBOnlyImageBlender : IImageBlender
+public class RGBOnlyImageBlender : ImageBlenderBase
 {
-    public Picture Blend(Picture from, Picture to)
+    protected override void BlendInternal(ReadOnlySpan<byte> fromSpan, byte[] toPixels, int fromPos, int toPos)
     {
-        return Blend(from, to, new Position(0, 0));
-    }
-
-    public Picture Blend(Picture from, Picture to, Position toPosition)
-    {
-        byte[] toPixels = to.CloneImage();
-
-        int startY = Math.Max(0, toPosition.Y);
-        int startX = Math.Max(0, toPosition.X);
-        int maxY = Math.Min(toPosition.Y + from.Height, to.Height);
-        int maxX = Math.Min(toPosition.X + from.Width, to.Width);
-
-        for (int y = startY; y < maxY; y++)
-        {
-            for (int x = startX; x < maxX; x++)
-            {
-                int toPos = (x * 4) + (to.Stride * y);
-                int fromPos = ((x - toPosition.X) * 4) + (from.Stride * (y - toPosition.Y));
-
-                ReadOnlySpan<byte> fromSpan = from.AsSpan();
-                toPixels[toPos + 0] = fromSpan[fromPos + 0];
-                toPixels[toPos + 1] = fromSpan[fromPos + 1];
-                toPixels[toPos + 2] = fromSpan[fromPos + 2];
-            }
-        }
-
-        return Picture.Create(to.Size, toPixels);
+        toPixels[toPos + 0] = fromSpan[fromPos + 0];
+        toPixels[toPos + 1] = fromSpan[fromPos + 1];
+        toPixels[toPos + 2] = fromSpan[fromPos + 2];
     }
 }


### PR DESCRIPTION
🎯 **What:** Extracted shared setup logic from four different blender classes into `ImageBlenderBase.cs`.
💡 **Why:** It removes heavy code duplication regarding bounds checking and iteration. It also promotes a pixel-index optimization loop (`toPos += 4`) across all blenders rather than duplicating offset lookups.
✅ **Verification:** Verified structural logic identically matches. Domain library builds cleanly.
✨ **Result:** A more maintainable image manipulation foundation that prevents repeating optimization fixes across multiple distinct blend methods.

---
*PR created automatically by Jules for task [3538198207859188336](https://jules.google.com/task/3538198207859188336) started by @arkfinn*