### PR TITLE
🔒 Fix potential information leakage in Velopack update service

### DIFF
--- a/Eede.Infrastructure/Updates/VelopackUpdateService.cs
+++ b/Eede.Infrastructure/Updates/VelopackUpdateService.cs
@@ -57,11 +57,11 @@ public class VelopackUpdateService : IUpdateService, IDisposable
             LatestVersion = _updateInfo.TargetFullRelease.Version.ToString();
             return true;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             // すでに IsInstalled でチェックしていますが、念のため例外もハンドリングします。
             // インストールされていない環境（デバッグ時など）ではエラー表示にせず、Idle ステータスに戻します。
-            System.Diagnostics.Debug.WriteLine($"Velopack CheckForUpdatesAsync error: {ex.Message}");
+            System.Diagnostics.Trace.WriteLine("Velopack CheckForUpdatesAsync failed due to an internal error.");
             SetStatus(UpdateStatus.Idle);
             return false;
         }
@@ -84,9 +84,9 @@ public class VelopackUpdateService : IUpdateService, IDisposable
             await mgr.DownloadUpdatesAsync(_updateInfo);
             SetStatus(UpdateStatus.ReadyToApply);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            System.Diagnostics.Debug.WriteLine($"Velopack DownloadUpdateAsync error: {ex.Message}");
+            System.Diagnostics.Trace.WriteLine("Velopack DownloadUpdateAsync failed due to an internal error.");
             SetStatus(UpdateStatus.Error);
         }
     }
@@ -103,9 +103,9 @@ public class VelopackUpdateService : IUpdateService, IDisposable
             }
             mgr.ApplyUpdatesAndRestart(_updateInfo);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            System.Diagnostics.Debug.WriteLine($"Velopack ApplyAndRestart error: {ex.Message}");
+            System.Diagnostics.Trace.WriteLine("Velopack ApplyAndRestart failed due to an internal error.");
             SetStatus(UpdateStatus.Error);
         }
     }


### PR DESCRIPTION
🎯 **What:** Fixed an information leakage vulnerability in `VelopackUpdateService.cs` where `ex.Message` was being logged directly to diagnostic debug output during update checks, downloads, and applies.

⚠️ **Risk:** Logging un-sanitized exception messages can inadvertently expose sensitive system information (such as internal file paths, network details, or environment variables) to logs. This is classified as an Information Exposure vulnerability (CWE-209).

🛡️ **Solution:** Modified the `catch` blocks in `CheckForUpdatesAsync`, `DownloadUpdateAsync`, and `ApplyAndRestart` to suppress the exact `Exception` contents. Instead of writing `ex.Message`, the application now logs a static, sanitized string message (e.g., `"Velopack <MethodName> failed due to an internal error."`) using `System.Diagnostics.Trace.WriteLine`. This maintains necessary diagnostic tracking while securely preventing data leakage.

---
*PR created automatically by Jules for task [10011768848317092732](https://jules.google.com/task/10011768848317092732) started by @arkfinn*