### PR TITLE
🔒 Fix command injection vulnerability in ExternalBrowserService

### DIFF
--- a/Eede.Infrastructure/Services/ExternalBrowserService.cs
+++ b/Eede.Infrastructure/Services/ExternalBrowserService.cs
@@ -14,7 +14,7 @@ public class ExternalBrowserService : IExternalBrowserService
             throw new ArgumentException("Invalid URL scheme. Only http and https are allowed.", nameof(url));
         }
 
-        StartProcess(url);
+        StartProcess(uri.AbsoluteUri);
     }
 
     protected virtual void StartProcess(string url)

--- a/Eede.Tests/Infrastructure/Services/ExternalBrowserServiceTests.cs
+++ b/Eede.Tests/Infrastructure/Services/ExternalBrowserServiceTests.cs
@@ -29,13 +29,16 @@ public class ExternalBrowserServiceTests
 
     [TestCase("http://example.com")]
     [TestCase("https://example.com")]
-    public void OpenUrl_ShouldNotThrow_WhenUrlIsSafe(string url)
+    [TestCase("http://example.com/unencoded space")]
+    [TestCase("http://example.com/\"&calc.exe")]
+    public void OpenUrl_ShouldNotThrow_AndUrlShouldBeEncoded_WhenUrlIsSafe(string url)
     {
         try
         {
             _service.OpenUrl(url);
+            var expectedUrl = new Uri(url).AbsoluteUri;
             Assert.That(_service.ProcessStarted, Is.True, "Should trigger process start");
-            Assert.That(_service.LastUrl, Is.EqualTo(url), "Should pass the correct URL");
+            Assert.That(_service.LastUrl, Is.EqualTo(expectedUrl), "Should pass the URL-encoded URL");
         }
         catch (ArgumentException ex)
         {


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability when opening URLs using `Process.Start` with `UseShellExecute = true`.
⚠️ **Risk:** An attacker could craft a specific malicious URL containing shell metacharacters (such as `&`, `|`, `"`). Due to `UseShellExecute = true`, when passed directly to `Process.Start`, these metacharacters could be interpreted by the operating system shell as command separators, leading to arbitrary code execution.
🛡️ **Solution:** Replaced the raw string argument with `uri.AbsoluteUri`. This safely canonicalizes and percent-encodes any unencoded unsafe characters. As a result, spaces become `%20`, quotes become `%22`, and so on, preventing the shell from treating them as command operators. Appropriate test cases were added to guarantee dangerous characters are properly URL-encoded.

---
*PR created automatically by Jules for task [2612256063500344578](https://jules.google.com/task/2612256063500344578) started by @arkfinn*