### PR TITLE
🔒 Fix potential information leakage in image saving trace log (CWE-209)

### DIFF
--- a/Eede.Presentation/Files/AbstractImageFile.cs
+++ b/Eede.Presentation/Files/AbstractImageFile.cs
@@ -43,7 +43,7 @@ namespace Eede.Presentation.Files
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine(ex);
+                System.Diagnostics.Trace.WriteLine($"Failed to save image: {ex.Message}");
                 return Task.FromResult(SaveImageResult.Canceled()); // エラーが発生した場合
             }
         }


### PR DESCRIPTION
🎯 **What:** Modified `AbstractImageFile.SaveToPathAsync` to log only the exception message instead of the full exception object when an error occurs during image saving.

⚠️ **Risk:** Logging the full exception object to Trace exposes the application's stack trace, internal file paths, and other sensitive system details in production logs, which could be leveraged by an attacker to map out the system internals (CWE-209).

🛡️ **Solution:** Updated `System.Diagnostics.Trace.WriteLine(ex);` to `System.Diagnostics.Trace.WriteLine($"Failed to save image: {ex.Message}");`, keeping the sanitized error message for debugging purposes while avoiding exposing internal system information.

---
*PR created automatically by Jules for task [3888522803731840774](https://jules.google.com/task/3888522803731840774) started by @arkfinn*