### PR TITLE
🔒 Fix exception detail leakage in JsonSettingsRepository trace logs

### DIFF
--- a/Eede.Infrastructure/Settings/JsonSettingsRepository.cs
+++ b/Eede.Infrastructure/Settings/JsonSettingsRepository.cs
@@ -27,9 +27,9 @@ public class JsonSettingsRepository : ISettingsRepository
             using var stream = File.OpenRead(_filePath);
             return await JsonSerializer.DeserializeAsync<AppSettings>(stream) ?? new AppSettings { GridWidth = 32, GridHeight = 32 };
         }
-        catch (System.Exception ex)
+        catch (System.Exception)
         {
-            System.Diagnostics.Trace.WriteLine($"Failed to load settings: {ex.Message}");
+            System.Diagnostics.Trace.WriteLine("Failed to load settings.");
             return new AppSettings { GridWidth = 32, GridHeight = 32 };
         }
     }
@@ -48,10 +48,10 @@ public class JsonSettingsRepository : ISettingsRepository
             await JsonSerializer.SerializeAsync(stream, settings);
             return true;
         }
-        catch (System.Exception ex)
+        catch (System.Exception)
         {
             // 保存失敗時はfalseを返して呼び出し元に通知する
-            System.Diagnostics.Trace.WriteLine($"Failed to save settings: {ex.Message}");
+            System.Diagnostics.Trace.WriteLine("Failed to save settings.");
             return false;
         }
     }

--- a/Eede.Tests/Infrastructure/Settings/JsonSettingsRepositoryTests.cs
+++ b/Eede.Tests/Infrastructure/Settings/JsonSettingsRepositoryTests.cs
@@ -49,4 +49,27 @@ public class JsonSettingsRepositoryTests
         Assert.That(loaded.GridWidth, Is.EqualTo(48));
         Assert.That(loaded.GridHeight, Is.EqualTo(64));
     }
+
+    [Test]
+    public async Task LoadAsync_HandlesExceptionGracefully()
+    {
+        // Using an invalid path containing null character to force an exception
+        var repository = new JsonSettingsRepository("invalid\0path");
+        var settings = await repository.LoadAsync();
+
+        Assert.That(settings, Is.Not.Null);
+        Assert.That(settings.GridWidth, Is.EqualTo(32));
+    }
+
+    [Test]
+    public async Task SaveAsync_HandlesExceptionGracefully()
+    {
+        // Using an invalid path containing null character to force an exception
+        var repository = new JsonSettingsRepository("invalid\0path");
+        var settings = new AppSettings { GridWidth = 48, GridHeight = 64 };
+
+        var result = await repository.SaveAsync(settings);
+
+        Assert.That(result, Is.False);
+    }
 }


### PR DESCRIPTION
🎯 **What:** 
The vulnerability fixed was the logging of raw exception messages (`ex.Message`) to the diagnostic trace in `Eede.Infrastructure/Settings/JsonSettingsRepository.cs`.

⚠️ **Risk:** 
If left unfixed, raw exception messages directly bound to system errors (such as path resolution errors, permission issues, or disk failures) would be written to the system trace, potentially leaking sensitive internal system structure or paths (CWE-209).

🛡️ **Solution:** 
The fix changes the trace output to use sanitized, generic string messages ("Failed to load settings." and "Failed to save settings.") instead of dynamically interpolating the raw exception message. The exception object binding (`ex`) was also removed to further ensure safety. New unit tests were added by passing null characters (`\0`) in the path string to force IO exceptions, confirming that the code safely handles errors without crashing.

---
*PR created automatically by Jules for task [1765402382572092334](https://jules.google.com/task/1765402382572092334) started by @arkfinn*