### PR TITLE
🔒 Fix potential command injection vulnerability in URL handler

### DIFF
--- a/Eede.Infrastructure/Services/ExternalBrowserService.cs
+++ b/Eede.Infrastructure/Services/ExternalBrowserService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Eede.Application.Infrastructure;
 
 namespace Eede.Infrastructure.Services;
@@ -19,10 +20,37 @@ public class ExternalBrowserService : IExternalBrowserService
 
     protected virtual void StartProcess(string url)
     {
-        Process.Start(new ProcessStartInfo
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            FileName = url,
-            UseShellExecute = true
-        });
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = url,
+                UseShellExecute = true
+            });
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "xdg-open",
+                UseShellExecute = false
+            };
+            psi.ArgumentList.Add(url);
+            Process.Start(psi);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "open",
+                UseShellExecute = false
+            };
+            psi.ArgumentList.Add(url);
+            Process.Start(psi);
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("Operating system not supported for opening external URLs.");
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** Fixed a potential command injection vulnerability in `ExternalBrowserService.cs`.
⚠️ **Risk:** On Linux and macOS, running `Process.Start` with `UseShellExecute = true` can sometimes route the URL to `/bin/sh` or equivalent. If an attacker could bypass initial URL validation (which currently only checks if it's an http/https absolute URI) or provide a complex URL with escaped characters (like spaces, `;`, or `&`), they could execute arbitrary shell commands on the user's host OS.
🛡️ **Solution:** Switched to an OS-specific execution model via `RuntimeInformation.IsOSPlatform`. On Linux and macOS, it directly invokes `xdg-open` and `open` respectively with `UseShellExecute = false`, and critically, uses `.ArgumentList.Add(url)` rather than `.Arguments`. This ensures the .NET framework strictly escapes the URL as a single, explicit argument to the process, bypassing the system shell entirely and negating injection vectors. On Windows, standard `UseShellExecute = true` is safely preserved.

---
*PR created automatically by Jules for task [1327010491717820125](https://jules.google.com/task/1327010491717820125) started by @arkfinn*