### PR TITLE
🔒 Fix generic exception catching in JsonSettingsRepository

### DIFF
--- a/Eede.Infrastructure/Settings/JsonSettingsRepository.cs
+++ b/Eede.Infrastructure/Settings/JsonSettingsRepository.cs
@@ -1,4 +1,5 @@
-﻿using Eede.Application.Infrastructure;
+﻿using System;
+using Eede.Application.Infrastructure;
 using Eede.Application.Settings;
 using System.IO;
 using System.Text.Json;
@@ -27,7 +28,7 @@ public class JsonSettingsRepository : ISettingsRepository
             using var stream = File.OpenRead(_filePath);
             return await JsonSerializer.DeserializeAsync<AppSettings>(stream) ?? new AppSettings { GridWidth = 32, GridHeight = 32 };
         }
-        catch (System.Exception)
+        catch (Exception ex) when (ex is JsonException || ex is IOException || ex is UnauthorizedAccessException || ex is ArgumentException || ex is NotSupportedException)
         {
             System.Diagnostics.Trace.WriteLine("Failed to load settings securely.");
             return new AppSettings { GridWidth = 32, GridHeight = 32 };
@@ -48,7 +49,7 @@ public class JsonSettingsRepository : ISettingsRepository
             await JsonSerializer.SerializeAsync(stream, settings);
             return true;
         }
-        catch (System.Exception)
+        catch (Exception ex) when (ex is JsonException || ex is IOException || ex is UnauthorizedAccessException || ex is ArgumentException || ex is NotSupportedException)
         {
             // 保存失敗時はfalseを返して呼び出し元に通知する
             System.Diagnostics.Trace.WriteLine("Failed to save settings securely.");


### PR DESCRIPTION
🎯 **What:** Modified `JsonSettingsRepository` to catch specific exceptions during file operations and JSON deserialization/serialization rather than catching the generic `System.Exception`.
⚠️ **Risk:** Catching `System.Exception` is a known anti-pattern and vulnerability. It can silently swallow critical, unrecoverable system exceptions like `OutOfMemoryException`, `ThreadAbortException`, or internal `NullReferenceException`s, potentially hiding bugs or leaving the application in a corrupted, exploitable state.
🛡️ **Solution:** Replaced `catch (System.Exception)` with an explicitly scoped C# exception filter: `catch (Exception ex) when (ex is JsonException || ex is IOException || ex is UnauthorizedAccessException || ex is ArgumentException || ex is NotSupportedException)`. This safely handles expected file and parsing failures while allowing fatal system exceptions to bubble up. Fixed this in both `LoadAsync` and `SaveAsync`.

---
*PR created automatically by Jules for task [6086429844483443106](https://jules.google.com/task/6086429844483443106) started by @arkfinn*