### PR TITLE
🧹 [Code Health] Remove commented out code in BackgroundColor.cs

### DIFF
--- a/Eede.Domain/ImageEditing/BackgroundColor.cs
+++ b/Eede.Domain/ImageEditing/BackgroundColor.cs
@@ -6,13 +6,6 @@ namespace Eede.Domain.ImageEditing;
 public readonly record struct BackgroundColor(ArgbColor Value)
 {
 
-    // public BackgroundColor
-    // {
-    // 背景色に特有の制約をここに定義する
-    // 例: 背景色は完全に透明にはできない、など
-    // }
-
-
     // デフォルトの背景色を提供する静的プロパティ
     public static BackgroundColor Default => new(new ArgbColor(0, 0, 0, 0));
 


### PR DESCRIPTION
🎯 **What:** Removed a block of commented-out code representing a constructor template in `BackgroundColor.cs`.
💡 **Why:** The commented-out block was dead code that added unnecessary noise and cognitive load to the file. Removing it improves readability and maintainability.
✅ **Verification:** The domain project builds successfully (`dotnet build Eede.Domain/Eede.Domain.csproj`), confirming no syntax errors were introduced. The NUnit test verification was skipped due to existing known NU3012 certificate issues on Linux blocks the build of test environment, but since this is just dead-code removal in comments, there is no behavioral risk.
✨ **Result:** A cleaner `BackgroundColor.cs` file with less dead code.

---
*PR created automatically by Jules for task [1359913301779578338](https://jules.google.com/task/1359913301779578338) started by @arkfinn*