### PR TITLE
🧪 Add missing test for AnimationViewModel empty patterns

### DIFF
--- a/Eede.Presentation/ViewModels/Animations/AnimationViewModel.cs
+++ b/Eede.Presentation/ViewModels/Animations/AnimationViewModel.cs
@@ -74,6 +74,7 @@ public partial class AnimationViewModel : ViewModelBase, IAddFrameProvider
 
     public void AddFrame(int cellIndex)
     {
+        // Safe execution when patterns might be empty
         AddFrameCommand.Execute(cellIndex).Subscribe();
     }
 

--- a/Eede.Tests/Presentation/ViewModels/Animations/AnimationViewModelTests.cs
+++ b/Eede.Tests/Presentation/ViewModels/Animations/AnimationViewModelTests.cs
@@ -6,6 +6,7 @@ using Eede.Application.UseCase.Animations;
 using Eede.Presentation.Common.Adapters;
 using Moq;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 
 namespace Eede.Presentation.Tests.ViewModels.Animations;
@@ -39,5 +40,20 @@ public class AnimationViewModelTests
         Assert.That(_viewModel.GridHeight, Is.EqualTo(32));
         Assert.That(_viewModel.WaitTime, Is.EqualTo(100));
         Assert.That(_viewModel.Patterns.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void AddFrame_WhenNoPatterns_ShouldNotThrowException()
+    {
+        // First pattern is added automatically if Patterns is empty during initialization.
+        // We simulate the removal of all patterns.
+        _viewModel.RemovePatternCommand.Execute().Subscribe();
+
+        Assert.That(_viewModel.Patterns.Count, Is.EqualTo(0), "Patterns collection should be empty.");
+        Assert.That(_viewModel.SelectedPattern, Is.Null, "SelectedPattern should be null.");
+
+        // Action under test
+        // AddFrame in Eede.Presentation/ViewModels/Animations/AnimationViewModel.cs is public and takes an int.
+        Assert.DoesNotThrow(() => _viewModel.AddFrame(0), "AddFrame should handle empty patterns gracefully.");
     }
 }


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `AnimationViewModel` edge case where `AddFrame` is called with an empty `Patterns` collection.
📊 **Coverage:** The scenario where a user calls `AddFrame` after removing all patterns is now safely covered by `AddFrame_WhenNoPatterns_ShouldNotThrowException` in `AnimationViewModelTests.cs`.
✨ **Result:** Verified that `AddFrame` executes gracefully without throwing a NullReferenceException, thereby increasing test reliability and robustness for edge cases.

---
*PR created automatically by Jules for task [14195082726863374829](https://jules.google.com/task/14195082726863374829) started by @arkfinn*