### PR TITLE
🧪 [Test] Add coverage for IdentityImageTransfer

### DIFF
--- a/Eede.Tests/Domain/ImageEditing/Transformation/IdentityImageTransferTests.cs
+++ b/Eede.Tests/Domain/ImageEditing/Transformation/IdentityImageTransferTests.cs
@@ -1,0 +1,31 @@
+using Eede.Domain.ImageEditing;
+using Eede.Domain.ImageEditing.Transformation;
+using Eede.Domain.SharedKernel;
+using NUnit.Framework;
+using System;
+
+namespace Eede.Domain.Tests.ImageEditing.Transformation;
+
+[TestFixture]
+public class IdentityImageTransferTests
+{
+    [Test]
+    public void Transfer_ReturnsSamePicture()
+    {
+        // Arrange
+        PictureSize size = new PictureSize(2, 2);
+        byte[] pixels = new byte[] {
+            255, 0, 0, 255,   0, 255, 0, 255,
+            0, 0, 255, 255,   255, 255, 255, 255
+        };
+        Picture src = Picture.Create(size, pixels);
+        IdentityImageTransfer transfer = new();
+        Magnification magnification = new(1);
+
+        // Act
+        Picture result = transfer.Transfer(src, magnification);
+
+        // Assert
+        Assert.That(result, Is.SameAs(src), "IdentityImageTransfer should return the exact same Picture instance.");
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added unit tests for the previously untested `IdentityImageTransfer` class in `Eede.Domain`.
📊 **Coverage:** The test covers the single `Transfer` method, verifying that it returns the exact same `Picture` reference passed to it, fulfilling the identity contract.
✨ **Result:** 100% test coverage for `IdentityImageTransfer`, ensuring its behavior remains correct and predictable during future refactoring.

---
*PR created automatically by Jules for task [16640604680276358602](https://jules.google.com/task/16640604680276358602) started by @arkfinn*