### PR TITLE
🧪 [Testing Improvement] Robust test for JsonSettingsRepository.SaveAsync exception handling

### DIFF
--- a/Eede.Tests/Infrastructure/Settings/JsonSettingsRepositoryTests.cs
+++ b/Eede.Tests/Infrastructure/Settings/JsonSettingsRepositoryTests.cs
@@ -64,12 +64,24 @@ public class JsonSettingsRepositoryTests
     [Test]
     public async Task SaveAsync_HandlesExceptionGracefully()
     {
-        // Using an invalid path containing null character to force an exception
-        var repository = new JsonSettingsRepository("invalid\0path");
-        var settings = new AppSettings { GridWidth = 48, GridHeight = 64 };
+        // Using a directory path to force an UnauthorizedAccessException
+        var dirPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dirPath);
+        try
+        {
+            var repository = new JsonSettingsRepository(dirPath);
+            var settings = new AppSettings { GridWidth = 48, GridHeight = 64 };
 
-        var result = await repository.SaveAsync(settings);
+            var result = await repository.SaveAsync(settings);
 
-        Assert.That(result, Is.False);
+            Assert.That(result, Is.False);
+        }
+        finally
+        {
+            if (Directory.Exists(dirPath))
+            {
+                Directory.Delete(dirPath, true);
+            }
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** Improved the testing strategy for the `JsonSettingsRepository.SaveAsync` method to simulate a legitimate file system failure. The previous test approach relied on a null character in the file path, which threw an `ArgumentException`. This change creates a temporary directory and uses its path to force an `UnauthorizedAccessException` instead.
📊 **Coverage:** The exception handling (`catch` block filtering `UnauthorizedAccessException`) when `File.WriteAllTextAsync` or `File.Create` fails is now thoroughly validated under realistic error conditions, without leaking temporary files to the file system.
✨ **Result:** A more robust and reliable unit test that accurately catches real potential file permission bugs during settings synchronization.

---
*PR created automatically by Jules for task [4988522190750970278](https://jules.google.com/task/4988522190750970278) started by @arkfinn*