### PR TITLE
🧪 Add tests for HsvColor.ToArgbColor

### DIFF
--- a/Eede.Tests/Domain/Palettes/HsvColorTests.cs
+++ b/Eede.Tests/Domain/Palettes/HsvColorTests.cs
@@ -26,5 +26,26 @@ namespace Eede.Domain.Tests.Palettes
         {
             Assert.That(HsvColor.FromHsv(1, 2, 3).GetHashCode(), Is.EqualTo(HsvColor.FromHsv(1, 2, 3).GetHashCode()));
         }
+
+        [TestCase(0, 255, 255, 255, 0, 0)] // Red
+        [TestCase(60, 255, 255, 255, 255, 0)] // Yellow
+        [TestCase(120, 255, 255, 0, 255, 0)] // Green
+        [TestCase(180, 255, 255, 0, 255, 255)] // Cyan
+        [TestCase(240, 255, 255, 0, 0, 255)] // Blue
+        [TestCase(300, 255, 255, 255, 0, 255)] // Magenta
+        [TestCase(360, 255, 255, 255, 0, 0)] // Hue 360 is same as 0 (Red)
+        [TestCase(0, 0, 0, 0, 0, 0)] // Black
+        [TestCase(0, 0, 255, 255, 255, 255)] // White
+        [TestCase(0, 0, 128, 128, 128, 128)] // Gray
+        public void ToArgbColorTest(int h, int s, int v, byte expectedR, byte expectedG, byte expectedB)
+        {
+            var hsv = HsvColor.FromHsv(h, s, v);
+            var argb = hsv.ToArgbColor();
+
+            Assert.That(argb.Alpha, Is.EqualTo(255));
+            Assert.That(argb.Red, Is.EqualTo(expectedR));
+            Assert.That(argb.Green, Is.EqualTo(expectedG));
+            Assert.That(argb.Blue, Is.EqualTo(expectedB));
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `HsvColor.ToArgbColor` method in `Eede.Domain.Palettes` was lacking test coverage, meaning regressions to color space conversion could go unnoticed.

📊 **Coverage:** What scenarios are now tested
Added parameterised NUnit tests covering the conversion of:
- Primary colors (Red, Green, Blue)
- Secondary colors (Yellow, Cyan, Magenta)
- Edge cases like Black, White, and Gray
- Wrap-around edge case for Hue (360 degrees being equivalent to 0 degrees)

✨ **Result:** The improvement in test coverage
The `ToArgbColor` logic is now fully verified against known mappings.

---
*PR created automatically by Jules for task [11726553713965329524](https://jules.google.com/task/11726553713965329524) started by @arkfinn*