### PR TITLE
🔒 Fix Process.Start UseShellExecute vulnerability

### DIFF
--- a/Eede.Infrastructure/Services/ExternalBrowserService.cs
+++ b/Eede.Infrastructure/Services/ExternalBrowserService.cs
@@ -22,11 +22,13 @@ public class ExternalBrowserService : IExternalBrowserService
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Process.Start(new ProcessStartInfo
+            var psi = new ProcessStartInfo
             {
-                FileName = url,
-                UseShellExecute = true
-            });
+                FileName = "explorer",
+                UseShellExecute = false
+            };
+            psi.ArgumentList.Add(url);
+            Process.Start(psi);
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability in `ExternalBrowserService.cs` where URLs were being opened on Windows using `Process.Start` with `UseShellExecute = true` and the URL assigned directly to `FileName`.
⚠️ **Risk:** Using `UseShellExecute = true` when passing untrusted or loosely validated user input to `Process.Start` can lead to arbitrary command execution (shell injection), as the URL string is evaluated by the Windows shell.
🛡️ **Solution:** Disabled `UseShellExecute` by setting it to `false`. Explicitly invoked `explorer` as the executable (`FileName`) and appended the URL to `ArgumentList`. This ensures the URL is treated safely as a distinct argument bypassing shell evaluation.

---
*PR created automatically by Jules for task [16162135388375121618](https://jules.google.com/task/16162135388375121618) started by @arkfinn*