### PR TITLE
🧹 [Code Health] Remove leftover Console.WriteLine from GradationSlider

### DIFF
--- a/Eede.Presentation/Views/DataEntry/GradationSlider.axaml.cs
+++ b/Eede.Presentation/Views/DataEntry/GradationSlider.axaml.cs
@@ -199,7 +199,6 @@ namespace Eede.Presentation.Views.DataEntry
         }
         private void UpdateValueByPositionY(double value)
         {
-            Console.WriteLine($"Height: {Height}, TickPolygon.Height: {TickPolygon.Height}, Mouse Y: {value}");
             Value = (int)(MaxValue - ((value - (TickPolygon.Height / 2)) / (Height - TickPolygon.Height) * (MaxValue - MinValue)));
         }
 


### PR DESCRIPTION
🎯 **What:** Removed a leftover `Console.WriteLine` statement from `Eede.Presentation/Views/DataEntry/GradationSlider.axaml.cs`.
💡 **Why:** This statement was left over from debugging and clutters the standard output. Removing it improves code health and maintainability.
✅ **Verification:** Verified the removal using `cat` and ran the full test suite using NUnit console runner to ensure no regressions were introduced.
✨ **Result:** A cleaner codebase with less console noise.

---
*PR created automatically by Jules for task [7513431270690392847](https://jules.google.com/task/7513431270690392847) started by @arkfinn*