### PR TITLE
🧹 Fix empty catch blocks in AvaloniaClipboard

### DIFF
--- a/Eede.Presentation/Common/Adapters/AvaloniaClipboard.cs
+++ b/Eede.Presentation/Common/Adapters/AvaloniaClipboard.cs
@@ -179,7 +179,10 @@ public class AvaloniaClipboard : IClipboard
             var bitmap = await dataTransfer.TryGetBitmapAsync();
             hasBitmap = (bitmap != null);
         }
-        catch {}
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.WriteLine($"ContainsImageAsync: TryGetBitmapAsync error: {ex.Message}");
+        }
 
         bool containsFile = dataTransfer.Contains(DataFormat.File);
 
@@ -205,8 +208,9 @@ public class AvaloniaClipboard : IClipboard
                     {
                         tcs.SetResult(System.Windows.Forms.Clipboard.ContainsImage());
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        System.Diagnostics.Trace.WriteLine($"ContainsImageAsync: Windows Forms Clipboard check error: {ex.Message}");
                         tcs.SetResult(false);
                     }
                 });
@@ -214,7 +218,10 @@ public class AvaloniaClipboard : IClipboard
                 thread.Start();
                 result = await tcs.Task;
             }
-            catch {}
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"ContainsImageAsync: Fallback thread error: {ex.Message}");
+            }
         }
 
         return result;


### PR DESCRIPTION
🎯 **What:** Modified empty `catch {}` and `catch` blocks in `Eede.Presentation/Common/Adapters/AvaloniaClipboard.cs` to explicitly catch `Exception ex` and log a sanitized error message using `System.Diagnostics.Trace.WriteLine`.
💡 **Why:** Empty catch blocks silently suppress exceptions, masking potential runtime errors during clipboard operations. Logging the exception messages improves code maintainability and debugging visibility without violating CWE-209 (no raw exception object exposure).
✅ **Verification:** Ran `dotnet test` (via nunit-console) to ensure no regressions were introduced. Confirmed changes locally.
✨ **Result:** Enhanced code health and diagnostic capabilities within the clipboard adapter without impacting user-facing behavior.

---
*PR created automatically by Jules for task [3161825485765993901](https://jules.google.com/task/3161825485765993901) started by @arkfinn*