### PR TITLE
🧹 [code health improvement] Document unsupported ConvertBack in PlayPauseTextConverter

### DIFF
--- a/Eede.Presentation/Common/Converters/PlayPauseTextConverter.cs
+++ b/Eede.Presentation/Common/Converters/PlayPauseTextConverter.cs
@@ -21,6 +21,7 @@ public class PlayPauseTextConverter : IValueConverter
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotSupportedException();
+        // One-way converter
+        throw new NotSupportedException("ConvertBack is not supported for this one-way converter.");
     }
 }


### PR DESCRIPTION
🎯 **What:** Documented the intentionally unsupported `ConvertBack` method in `PlayPauseTextConverter`.
💡 **Why:** This clarifies the intent that the converter is strictly one-way and improves code readability. Throwing an explicit `NotSupportedException` with a message is semantically correct for one-way bindings and removes ambiguity.
✅ **Verification:** Verified the file changes manually. Ran the compilation to ensure it builds successfully.
✨ **Result:** Improved code health and maintainability for the converter without any behavioral changes.

---
*PR created automatically by Jules for task [1462777154980821383](https://jules.google.com/task/1462777154980821383) started by @arkfinn*